### PR TITLE
Fix UnicodeDecodeError when parsing non-utf8 log files

### DIFF
--- a/cabrillo/parser.py
+++ b/cabrillo/parser.py
@@ -141,5 +141,5 @@ def parse_log_file(filename, ignore_unknown_key=False, check_categories=True, ig
         Raises:
             InvalidQSOException, InvalidLogException
     """
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding='unicode_escape') as f:
         return parse_log_text(f.read(), ignore_unknown_key, check_categories, ignore_order)


### PR DESCRIPTION
When parsing many Cabrillo log files, some of them might be encoded
differently. Some parse operations might throw similar errors:

  UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in
  position 302: invalid continuation byte

This fix escapes the unicode sequences in those files and can parse
the below formats:

* iso-8859-1
* us-ascii
* utf-8